### PR TITLE
Make a fresh machine work out of the box: git, claude

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,14 +7,14 @@ DEST="$HOME/.dotfiles"
 info()  { printf "\033[0;32m==>\033[0m %s\n" "$1"; }
 error() { printf "\033[0;31m==>\033[0m %s\n" "$1"; exit 1; }
 
-if ! xcode-select -p >/dev/null 2>&1; then
-  info "Xcode Command Line Tools not found. Installing..."
-  xcode-select --install || true
-  error "Finish the Xcode CLT install in the popup, then re-run: curl -fsSL https://fmontes.com/install.sh | bash"
-fi
-
-if ! command -v git >/dev/null 2>&1; then
-  error "git not found. Install Xcode Command Line Tools and re-run."
+if ! xcode-select -p >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+  info "Xcode Command Line Tools (provides git) not found. Installing..."
+  xcode-select --install >/dev/null 2>&1 || true
+  info "Accept the popup. Waiting for the install to finish..."
+  until xcode-select -p >/dev/null 2>&1 && command -v git >/dev/null 2>&1; do
+    sleep 5
+  done
+  info "Command Line Tools ready."
 fi
 
 if [[ -d "$DEST" ]]; then

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -21,6 +21,7 @@ export BUN_INSTALL="$HOME/.bun"
 export DOCKER_HOST=unix:///var/run/docker.sock
 
 # ─── PATH ───────────────────────────────────────────────────────────────────
+export PATH="$HOME/.local/bin:$PATH"   # claude and other native-installer bins
 export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
 case ":$PATH:" in
   *":$PNPM_HOME:"*) ;;

--- a/scripts/01-xcode.sh
+++ b/scripts/01-xcode.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env zsh
-if ! xcode-select -p &>/dev/null; then
-  echo "Installing Xcode Command Line Tools..."
-  xcode-select --install
-  echo "Press any key once installation completes..."
-  read -k 1
-else
+if xcode-select -p &>/dev/null && command -v git &>/dev/null; then
   echo "Xcode CLT already installed."
+  return 0 2>/dev/null || exit 0
 fi
+
+echo "Installing Xcode Command Line Tools..."
+xcode-select --install 2>/dev/null || true
+
+# The install runs in a separate GUI process, so poll until git actually
+# works rather than trusting a keypress — otherwise later steps race a
+# half-finished CLT install.
+echo "Waiting for the Command Line Tools install to finish (accept the popup)..."
+until xcode-select -p &>/dev/null && command -v git &>/dev/null; do
+  sleep 5
+done
+echo "Xcode CLT ready."

--- a/scripts/07-post-install.sh
+++ b/scripts/07-post-install.sh
@@ -10,6 +10,9 @@ fi
 # Use the official native installer rather than the npm package — the npm
 # global install can skip the platform-native binary (--ignore-scripts /
 # --omit=optional), leaving a `claude` on PATH that exists but won't run.
+# The installer drops the binary in ~/.local/bin, which this script's PATH
+# may not include yet — add it so the run-check and verification work here.
+export PATH="$HOME/.local/bin:$PATH"
 # Test that it actually runs, not just that it's present, so a broken npm
 # install gets replaced.
 if claude --version &>/dev/null; then
@@ -17,6 +20,11 @@ if claude --version &>/dev/null; then
 else
   echo "Installing Claude Code..."
   curl -fsSL https://claude.ai/install.sh | bash || echo "Claude Code install failed — run 'curl -fsSL https://claude.ai/install.sh | bash' manually."
+  if claude --version &>/dev/null; then
+    echo "Claude Code ready."
+  else
+    echo "Claude Code still not runnable — check ~/.local/bin/claude manually."
+  fi
 fi
 
 # ─── Global npm packages ─────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes three gaps that broke a truly-clean install (`git` missing, `claude` not found after bootstrap).

## `git` — chicken-and-egg at clone time
`bootstrap.sh` needs `git` to clone the repo, but `git` ships with Xcode Command Line Tools and that install is an **async GUI popup**. The old flow errored out ("finish the popup, then re-run") and, in the in-repo `01-xcode.sh`, trusted a keypress that can fire before the install actually finishes.

- **bootstrap.sh** — install CLT and **poll until `git` works** before cloning
- **scripts/01-xcode.sh** — same poll-until-ready loop instead of `read -k 1`

## `claude` — not on PATH out of the box
The native installer drops `claude` in `~/.local/bin`, which only reached PATH via the installer's `env` file — and that file doesn't exist when the shell first starts on a fresh machine, so `claude` was invisible until a manual reload.

- **home/.zshrc** — put `~/.local/bin` on PATH directly (not dependent on the installer's env file)
- **scripts/07-post-install.sh** — add `~/.local/bin` to PATH in the script too, and re-verify `claude --version` after install so a failure is reported, not silent

## Result
Fresh Mac → one `curl … | bash` → `git`, `claude`, and everything else present with no manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)